### PR TITLE
chore: bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
     "node": ">=14.17.0"
   },
   "dependencies": {
-    "electron-store": "^8.0.1"
+    "electron-store": "^8.0.2"
   },
   "devDependencies": {
-    "@types/react": "^18.0.12",
-    "@types/react-dom": "^18.0.5",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^1.3.2",
-    "electron": "^19.0.3",
-    "electron-builder": "^23.0.3",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "sass": "^1.52.2",
-    "typescript": "^4.7.3",
-    "vite": "^2.9.10",
-    "vite-plugin-electron": "^0.6.2"
+    "electron": "^19.0.8",
+    "electron-builder": "^23.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "sass": "^1.53.0",
+    "typescript": "^4.7.4",
+    "vite": "^2.9.14",
+    "vite-plugin-electron": "^0.7.5"
   },
   "env": {
     "VITE_DEV_SERVER_HOST": "127.0.0.1",


### PR DESCRIPTION
electron-store          ^8.0.1  →    ^8.0.2     
 @types/react          ^18.0.12  →  ^18.0.15     
 @types/react-dom       ^18.0.5  →   ^18.0.6     
 electron               ^19.0.3  →   ^19.0.8     
 electron-builder       ^23.0.3  →   ^23.1.0     
 react                  ^18.1.0  →   ^18.2.0     
 react-dom              ^18.1.0  →   ^18.2.0     
 sass                   ^1.52.2  →   ^1.53.0     
 typescript              ^4.7.3  →    ^4.7.4     
 vite                   ^2.9.10  →   ^2.9.14     
 vite-plugin-electron    ^0.6.2  →    ^0.7.5     
