### PR TITLE
The task 'start .debug.script.mjs' cannot be tracked | Cannot connect to the target at localhost:9229

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,8 @@
       "name": "Debug Renderer Process",
       "port": 9229,
       "request": "attach",
-      "type": "pwa-chrome"
+      "type": "pwa-chrome",
+      "timeout": 60000
     },
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,23 @@
       "type": "shell",
       "command": "node .vscode/.debug.script.mjs",
       "isBackground": true,
-      "problemMatcher": []
+      "problemMatcher": {
+        "owner": "typescript",
+        "fileLocation": "relative",
+        "pattern": {
+          "regexp": "^([a-zA-Z]\\:\/?([\\w\\-]\/?)+\\.\\w+):(\\d+):(\\d+): (ERROR|WARNING)\\: (.*)$",
+          "file": 1,
+          "line": 3,
+          "column": 4,
+          "code": 5,
+          "message": 6
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^.*building for development.*$",
+          "endsPattern": "built in [0-9]*ms.*$",
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
1. 🌱 034f89c fix(Debug): `The task 'start .debug.script.mjs' cannot be tracked`

<img width="528" alt="image" src="https://user-images.githubusercontent.com/26263658/182066972-0cbab534-dc41-4bc9-9c30-adad1846aea4.png">

2. 🌱 b8eaa24 fix(Debug): `Cannot connect to the target at localhost:9229`

<img width="420" alt="image" src="https://user-images.githubusercontent.com/26263658/182067097-52c0fdd0-effa-49e6-ae4e-b5f43b860ea3.png">

reference: https://github.com/electron-vite/electron-vite-boilerplate/pull/29
