### PR TITLE
bump devpendencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@types/react": "^18.0.15",
+    "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
-    "@vitejs/plugin-react": "^2.0.0",
-    "electron": "^19.0.9",
-    "electron-builder": "^23.1.0",
+    "@vitejs/plugin-react": "^2.0.1",
+    "electron": "^20.0.2",
+    "electron-builder": "^23.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sass": "^1.53.0",
+    "sass": "^1.54.4",
     "typescript": "^4.7.4",
-    "vite": "^3.0.2",
-    "vite-plugin-electron": "^0.8.3"
+    "vite": "^3.0.7",
+    "vite-plugin-electron": "^0.9.0"
   },
   "env": {
     "VITE_DEV_SERVER_HOST": "127.0.0.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,6 @@ export default defineConfig({
       // https://github.com/electron-vite/vite-plugin-electron/tree/main/packages/electron-renderer#electron-renderervite-serve
       renderer: {},
     }),
-    renderBuiltUrl(),
   ],
   server: {
     host: pkg.env.VITE_DEV_SERVER_HOST,
@@ -71,60 +70,4 @@ function withDebug(config: UserConfig): UserConfig {
     })
   }
   return config
-}
-
-// Only worked Vite@3.x #52
-function renderBuiltUrl(): Plugin {
-  // https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L84-L124
-  const KNOWN_ASSET_TYPES = [
-    // images
-    'png',
-    'jpe?g',
-    'jfif',
-    'pjpeg',
-    'pjp',
-    'gif',
-    'svg',
-    'ico',
-    'webp',
-    'avif',
-
-    // media
-    'mp4',
-    'webm',
-    'ogg',
-    'mp3',
-    'wav',
-    'flac',
-    'aac',
-
-    // fonts
-    'woff2?',
-    'eot',
-    'ttf',
-    'otf',
-
-    // other
-    'webmanifest',
-    'pdf',
-    'txt'
-  ]
-
-  return {
-    name: 'render-built-url',
-    config(config) {
-      config.experimental = {
-        renderBuiltUrl(filename, type) {
-          if (
-            KNOWN_ASSET_TYPES.includes(path.extname(filename).slice(1)) &&
-            type.hostType === 'js'
-          ) {
-            // Avoid Vite relative-path assets handling
-            // https://github.com/vitejs/vite/blob/89dd31cfe228caee358f4032b31fdf943599c842/packages/vite/src/node/build.ts#L838-L875
-            return { runtime: JSON.stringify(filename) }
-          }
-        },
-      }
-    },
-  }
 }


### PR DESCRIPTION
- bump devpendencies

 @types/react          ^18.0.15  →  ^18.0.17     
 @vitejs/plugin-react    ^2.0.0  →    ^2.0.1     
 electron               ^19.0.9  →   ^20.0.2     
 electron-builder       ^23.1.0  →   ^23.3.3     
 sass                   ^1.53.0  →   ^1.54.4     
 vite                    ^3.0.2  →    ^3.0.7    

- remove renderBUiltUrl