### PR TITLE
fix: incorrect debounce call

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({ command }) => {
           ...(!!process.env.VSCODE_DEBUG
             ? [
               // Will start Electron via VSCode Debug
-              customStart(() => debounce(() => console.log(/* For `.vscode/.debug.script.mjs` */'[startup] Electron App'))),
+              customStart(debounce(() => console.log(/* For `.vscode/.debug.script.mjs` */'[startup] Electron App'))),
             ]
             : []),
           // Allow use `import.meta.env.VITE_SOME_KEY` in Electron-Main


### PR DESCRIPTION
Debug cannot be started because of an incorrect `debounce` call.