### PR TITLE
fix: Rename PUBLIC environment variable to avoid problems with child_process

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -15,7 +15,7 @@ import { update } from './update'
 //
 process.env.DIST_ELECTRON = join(__dirname, '../')
 process.env.DIST = join(process.env.DIST_ELECTRON, '../dist')
-process.env.PUBLIC_ELECTRON = process.env.VITE_DEV_SERVER_URL
+process.env.VITE_PUBLIC = process.env.VITE_DEV_SERVER_URL
   ? join(process.env.DIST_ELECTRON, '../public')
   : process.env.DIST
 
@@ -44,7 +44,7 @@ const indexHtml = join(process.env.DIST, 'index.html')
 async function createWindow() {
   win = new BrowserWindow({
     title: 'Main window',
-    icon: join(process.env.PUBLIC_ELECTRON!, 'favicon.ico'),
+    icon: join(process.env.VITE_PUBLIC!, 'favicon.ico'),
     webPreferences: {
       preload,
       // Warning: Enable nodeIntegration and disable contextIsolation is not secure in production

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -15,7 +15,7 @@ import { update } from './update'
 //
 process.env.DIST_ELECTRON = join(__dirname, '../')
 process.env.DIST = join(process.env.DIST_ELECTRON, '../dist')
-process.env.PUBLIC = process.env.VITE_DEV_SERVER_URL
+process.env.PUBLIC_ELECTRON = process.env.VITE_DEV_SERVER_URL
   ? join(process.env.DIST_ELECTRON, '../public')
   : process.env.DIST
 
@@ -44,7 +44,7 @@ const indexHtml = join(process.env.DIST, 'index.html')
 async function createWindow() {
   win = new BrowserWindow({
     title: 'Main window',
-    icon: join(process.env.PUBLIC, 'favicon.ico'),
+    icon: join(process.env.PUBLIC_ELECTRON!, 'favicon.ico'),
     webPreferences: {
       preload,
       // Warning: Enable nodeIntegration and disable contextIsolation is not secure in production


### PR DESCRIPTION
The PUBLIC environment variable is defined to the Vite public directory and can cause many problems when using child_process (on Windows) because this variable point usually on the public user directory (C:\Users\Public on Windows). This cause errors when launching games for example which can't find saves